### PR TITLE
fix: Use HTTPS when opening KoL wiki link

### DIFF
--- a/relay/relay_OCD_dB_Manager.ash
+++ b/relay/relay_OCD_dB_Manager.ash
@@ -189,7 +189,7 @@ void styles() {
 	
 	page.append("<script language=Javascript>"+
 	"function wikiitem(desc) {"+
-	"	newwindow=window.open('http://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=' + desc + '&go=Go');"+
+	"	newwindow=window.open('https://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=' + desc + '&go=Go');"+
 	"		if (window.focus) {newwindow.focus()}"+
 	"}"+
 	"</script>");


### PR DESCRIPTION
Previously, the script linked an item to its KoL wiki page using the HTTP address. This was then redirected by kol.coldfront.net to HTTPS, but the redirected URLs somtimes ended up broken.

Directly linking to the HTTPS site solves the issue.

See related discussion at:
- https://kolmafia.us/threads/ocd-inventory-control.1818/post-160872