### PR TITLE
Extract CSS and JS into separate files

### DIFF
--- a/release/relay/ocd-db-manager/ocd-db-manager.web.js
+++ b/release/relay/ocd-db-manager/ocd-db-manager.web.js
@@ -1,0 +1,34 @@
+/**
+ * @file Supporting script for relay_OCD_dB_Manager.ash.
+ * This is meant to be served to a web browser, not executed by KoLmafia!
+ */
+
+/**
+ * Open a small popup showing an item's in-game description.
+ * @param {number | string} desc Item descid
+ */
+function descitem(desc) {
+  newwindow = window.open(
+    "/desc_item.php?whichitem=" + desc,
+    "name",
+    "height=200,width=214"
+  );
+  if (window.focus) {
+    newwindow.focus();
+  }
+}
+
+/**
+ * Open a new window showing the KoL wiki page for an item.
+ * @param {string} desc Item name (= KoL wiki page name)
+ */
+function wikiitem(desc) {
+  newwindow = window.open(
+    "https://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=" +
+      desc +
+      "&go=Go"
+  );
+  if (window.focus) {
+    newwindow.focus();
+  }
+}

--- a/release/relay/ocd-db-manager/styles.css
+++ b/release/relay/ocd-db-manager/styles.css
@@ -1,0 +1,128 @@
+th {
+  background-color: blue;
+  color: white;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+fieldset {
+  background-color: white;
+  margin-top: 3px;
+  padding-top: 10px;
+  padding-bottom: 15px;
+}
+
+legend {
+  font-size: 110%;
+  color: black;
+}
+
+a:link {
+  color: black;
+  text-decoration: none;
+}
+
+a:visited {
+  color: black;
+  text-decoration: none;
+}
+
+a:hover {
+  color: blue;
+  text-decoration: underline;
+}
+
+a.red:link {
+  color: red;
+}
+
+a.red:visited {
+  color: red;
+}
+
+a.version:link {
+  color: #0000cd;
+}
+
+a.version:visited {
+  color: #0000cd;
+}
+
+a.version:hover {
+  color: red;
+}
+
+p.zlib {
+  margin: 5px 20px;
+  font-size: 88%;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+table.zlib {
+  margin: 0px 20px;
+  font-size: 88%;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+tr.item:hover {
+  background-color: silver;
+}
+
+ul.stock {
+  list-style-type: none;
+  margin-bottom: 20;
+  margin-top: 0;
+  padding: 0;
+  position: relative;
+  top: 5;
+  left: 10;
+  width: 100%;
+}
+
+input {
+  margin-bottom: -2;
+}
+
+input.nav {
+  margin-bottom: -1;
+  padding: 0;
+  font-size: 100%;
+}
+
+ul.tabbernav {
+  margin: 0;
+  padding: 3px 1px 0;
+  border-bottom: 1px solid black;
+  font: bold 12px Verdana, sans-serif;
+}
+
+ul.tabbernav li {
+  list-style: none;
+  margin: 0;
+  display: inline;
+}
+
+ul.tabbernav li input {
+  padding: 3px 0.5em;
+  margin-left: 3px;
+  border: 1px solid black;
+  border-bottom: 1px solid black;
+  background: #ddddee;
+  text-decoration: none;
+}
+
+ul.tabbernav li input:hover {
+  color: #000000;
+  background: #aaaaee;
+  border-color: black;
+}
+
+ul.tabbernav li.tabberactive input {
+  background-color: white;
+  border-bottom: 1px solid white;
+}
+
+ul.tabbernav li.tabberactive input:hover {
+  color: #000000;
+  background: white;
+  border-bottom: 1px solid white;
+}

--- a/release/relay/relay_OCD_dB_Manager.ash
+++ b/release/relay/relay_OCD_dB_Manager.ash
@@ -180,20 +180,7 @@ string write_hidden(string ov, string name) {
 }
 
 void styles() {
-	page.append("<script language=Javascript>"+
-	"function descitem(desc) {"+
-	"	newwindow=window.open('/desc_item.php?whichitem='+desc,'name','height=200,width=214');"+
-	"		if (window.focus) {newwindow.focus()}"+
-	"}"+
-	"</script>");
-
-	page.append("<script language=Javascript>"+
-	"function wikiitem(desc) {"+
-	"	newwindow=window.open('https://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=' + desc + '&go=Go');"+
-	"		if (window.focus) {newwindow.focus()}"+
-	"}"+
-	"</script>");
-
+	page.append('<script src="/ocd-db-manager/ocd-db-manager.web.js"></script>\n');
 	page.append('<link rel="stylesheet" href="/ocd-db-manager/styles.css">\n');
 }
 

--- a/release/relay/relay_OCD_dB_Manager.ash
+++ b/release/relay/relay_OCD_dB_Manager.ash
@@ -194,38 +194,7 @@ void styles() {
 	"}"+
 	"</script>");
 
-	page.append("<style type='text/css'>"+
-	"th {background-color:blue; color:white; font-family:Arial,Helvetica,sans-serif;}"+
-
-	"fieldset {background-color:white; margin-top: 3px; padding-top:10px; padding-bottom:15px;}"+
-	"legend {font-size:110%; color:black;}"+
-
-	"a:link {color:black; text-decoration:none;}"+
-	"a:visited {color:black; text-decoration:none;}"+
-	"a:hover {color:blue; text-decoration:underline;}"+
-	"a.red:link {color:red}"+
-	"a.red:visited {color:red}"+
-	"a.version:link {color:#0000CD}"+
-	"a.version:visited {color:#0000CD}"+
-	"a.version:hover {color:red;}"+
-
-	"p.zlib {margin:5px 20px; font-size:88%; font-family:Arial,Helvetica,sans-serif;}"+
-	"table.zlib {margin:0px 20px; font-size:88%; font-family:Arial,Helvetica,sans-serif;}"+
-	"tr.item:hover {background-color:silver;}"+
-
-	"ul.stock {list-style-type:none;margin-bottom:20;margin-top:0;padding:0;position: relative;top:5;left:10;width:100%;}"+
-
-	"input {margin-bottom:-2;}"+   // This corrects for buttons adding extra margin onto the bottom of a table. :(
-	"input.nav {margin-bottom:-1; padding: 0; font-size:100%;}"+
-
-	"ul.tabbernav {margin:0; padding: 3px 1px 0; border-bottom: 1px solid black; font: bold 12px Verdana, sans-serif;}"+
-	"ul.tabbernav li {list-style: none; margin: 0; display: inline;}"+
-	"ul.tabbernav li input {padding: 3px 0.5em; margin-left: 3px; border: 1px solid black;"+
-		" border-bottom: 1px solid black; background: #DDDDEE; text-decoration: none;}"+
-	"ul.tabbernav li input:hover {color: #000000; background: #AAAAEE; border-color: black;}"+
-	"ul.tabbernav li.tabberactive input {background-color: white; border-bottom: 1px solid white;}"+
-	"ul.tabbernav li.tabberactive input:hover {color: #000000; background: white; border-bottom: 1px solid white;}"+
-	"</style>");
+	page.append('<link rel="stylesheet" href="/ocd-db-manager/styles.css">\n');
 }
 
 void load_OCD() {

--- a/release/relay/relay_OCD_dB_Manager.ash
+++ b/release/relay/relay_OCD_dB_Manager.ash
@@ -186,7 +186,7 @@ void styles() {
 	"		if (window.focus) {newwindow.focus()}"+
 	"}"+
 	"</script>");
-	
+
 	page.append("<script language=Javascript>"+
 	"function wikiitem(desc) {"+
 	"	newwindow=window.open('https://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=' + desc + '&go=Go');"+
@@ -196,10 +196,10 @@ void styles() {
 
 	page.append("<style type='text/css'>"+
 	"th {background-color:blue; color:white; font-family:Arial,Helvetica,sans-serif;}"+
-	
+
 	"fieldset {background-color:white; margin-top: 3px; padding-top:10px; padding-bottom:15px;}"+
 	"legend {font-size:110%; color:black;}"+
-	
+
 	"a:link {color:black; text-decoration:none;}"+
 	"a:visited {color:black; text-decoration:none;}"+
 	"a:hover {color:blue; text-decoration:underline;}"+
@@ -208,16 +208,16 @@ void styles() {
 	"a.version:link {color:#0000CD}"+
 	"a.version:visited {color:#0000CD}"+
 	"a.version:hover {color:red;}"+
-	
+
 	"p.zlib {margin:5px 20px; font-size:88%; font-family:Arial,Helvetica,sans-serif;}"+
 	"table.zlib {margin:0px 20px; font-size:88%; font-family:Arial,Helvetica,sans-serif;}"+
 	"tr.item:hover {background-color:silver;}"+
-	
+
 	"ul.stock {list-style-type:none;margin-bottom:20;margin-top:0;padding:0;position: relative;top:5;left:10;width:100%;}"+
 
 	"input {margin-bottom:-2;}"+   // This corrects for buttons adding extra margin onto the bottom of a table. :(
 	"input.nav {margin-bottom:-1; padding: 0; font-size:100%;}"+
-	
+
 	"ul.tabbernav {margin:0; padding: 3px 1px 0; border-bottom: 1px solid black; font: bold 12px Verdana, sans-serif;}"+
 	"ul.tabbernav li {list-style: none; margin: 0; display: inline;}"+
 	"ul.tabbernav li input {padding: 3px 0.5em; margin-left: 3px; border: 1px solid black;"+
@@ -227,7 +227,7 @@ void styles() {
 	"ul.tabbernav li.tabberactive input:hover {color: #000000; background: white; border-bottom: 1px solid white;}"+
 	"</style>");
 }
-	
+
 void load_OCD() {
 	if(count(fields) > 0) return;
 	string OCDfile = "OCDdata_"+getvar("BaleOCD_DataFile")+".txt";
@@ -346,7 +346,7 @@ string image(item doodad) {
 }
 
 string desc(item doodad) {
-	return  "<a title = \"Open wiki page in a new window\" href=\"javascript:wikiitem('" 
+	return  "<a title = \"Open wiki page in a new window\" href=\"javascript:wikiitem('"
 		+ replace_string(to_string(doodad), "'", "\\'")
 		+ "');\">" + doodad +"</a>";
 }
@@ -452,7 +452,7 @@ void add_items() {
 		if(is_OCDable(doodad) && !(OCD contains doodad && OCD[doodad].action != "UNKN")) {
 			if(!table_started) {
 				page.add_catbuttons();
-				
+
 				page.append("<table border=0 cellpadding=1>");
 				page.append("<tr>");
 				page.append("<th colspan=2>Item</th>");
@@ -466,7 +466,7 @@ void add_items() {
 				table_started = true;
 			}
 			page.append("<tr valign=center class='item'");
-			if(count(stock) > 0 && getvar("BaleOCD_Stock").to_int() > 0 
+			if(count(stock) > 0 && getvar("BaleOCD_Stock").to_int() > 0
 			  && stock contains doodad && stock[doodad].q >= item_amount(doodad))
 				page.append(" style='background-color:E3E3E3'");
 			page.append("><td>"+imagedesc(doodad)+"</a></td>");
@@ -633,11 +633,11 @@ void edit_items(string act) {
 				page.append("</td></tr>");
 			}
 			page.append("</table>");
-		} else if(act == "Search" && fields["searchbox"].length() > 0) 
+		} else if(act == "Search" && fields["searchbox"].length() > 0)
 			page.append("<p style='text-indent:3%; color:#FF6666'>No search results found. Try searching for a partial match.</p>");
 		page.append("</fieldset>"); 	// finish_box()
 	}
-	
+
 	switch(act) {
 	case "Keep":
 		fieldset = "Manage Items to Keep";
@@ -708,9 +708,9 @@ void edit_items(string act) {
 
 void stock_items() {
 	item [int] ostock;
-	
+
 	page.append("<fieldset><legend>Items to keep in stock</legend>"); // write_box()
-	
+
 	page.append("What to do with items on this list?<ul class='stock'><li>");
 	vars["BaleOCD_Stock"] = write_radio(getvar("BaleOCD_Stock"), "stock", " Acquire these items for future use", 1);
 	page.append("</li><li>");
@@ -718,7 +718,7 @@ void stock_items() {
 	page.append("</li><li>");
 	write_radio(getvar("BaleOCD_Stock"), "stock", " Ignore this stock list", 0);
 	page.append("</li></ul>");
-	
+
 	page.append("<table border=0 cellpadding=1><tr><td align=right>");
 	if(write_button("stocknew", " New ")) {
 		clear(stock);
@@ -738,7 +738,7 @@ void stock_items() {
 		page.append("</td><td>Delete <i>all</i> entries in the following list!</td></tr>");
 	}
 	page.append("</table><br />");
-				
+
 	if(count(stock) > 0) {
 		page.append("<table border=0 cellpadding=1>");
 		page.append("<tr><th>Purpose</th><th colspan=2>Item</th><th>Have</th><th>Stock</th><th>Delete?</th></tr>");
@@ -827,7 +827,7 @@ void set_cats() {
 
 void zlib_vars() {
 	page.append("<fieldset><legend>Configure Character Settings</legend>"); // write_box()
-	
+
 	page.append("<table class='zlib' border=0 cellpadding=1>");
 	page.append("<tr><td align=right>Empty Closet First: </td><td>");
 	if(getvar("BaleOCD_EmptyCloset") != "-1" && getvar("BaleOCD_EmptyCloset") != "0") vars["BaleOCD_EmptyCloset"] = 0;
@@ -841,11 +841,11 @@ void zlib_vars() {
 	vars["BaleOCD_Pricing"] = write_radio(getvar("BaleOCD_Pricing"), "Pricing", "Automatic,", "auto");
 	write_radio(getvar("BaleOCD_Pricing"), "Pricing", "999,999,999 meat.", "max");
 	page.append("</td></tr></table>");
-	
+
 	page.append("<p class='zlib'>");
 	vars["BaleOCD_Sim"] = write_check(getvar("BaleOCD_Sim"), "Sim", "Simulate Only ");
 	page.append(" <font size=1>(no actions will be taken)</font></p>");
-	
+
 	page.append("<table class='zlib' border=0 cellpadding=1><tr><td align=right>My Mall Multi:</td><td>");
 	vars["BaleOCD_MallMulti"] = write_field(getvar("BaleOCD_MallMulti"), "MallMulti", 14);
 	page.append("</td><td align=right>&nbsp;&nbsp;Mall Multi kMail Text</td><td>");
@@ -853,7 +853,7 @@ void zlib_vars() {
 	page.append("</td></tr><tr><td colspan=2>");
 	vars["BaleOCD_UseMallMulti"] = write_check(getvar("BaleOCD_UseMallMulti"), "UseMulti", "Use Mall Multi");
 	page.append("</td></tr></table>");
-	
+
 	page.append("<p class='zlib'>Data file: OCDdata_");
 	vars["BaleOCD_DataFile"] = write_field(getvar("BaleOCD_DataFile"), "DataFile", 10);
 	if(getvar("BaleOCD_DataFile") == "")
@@ -875,7 +875,7 @@ void zlib_vars() {
 		page.append("<script language='javascript'>ourDate = new Date();document.write(' at '+ ourDate.toLocaleString() + '.<br/>');</script></div>");
 	}
 	page.append("</p>");
-	
+
 	page.append("</fieldset>"); 	// finish_box()
 }
 
@@ -957,7 +957,7 @@ void subcat_tabs() {
 	if(count(todos) > 0) write_tab("editTab", "Reminders");
 	write_tab("editTab", "Search");
 	page.append("<li></ul>");
-	
+
 	edit_items(fields["editTab"]);
 }
 
@@ -998,7 +998,7 @@ void main() {
 	styles();
 	page.append("</head><body><form name='relayform' method='POST' action=''>");
 	page.append("<input type='submit' name='no show' value='donothing' style='position: absolute; left: -9999px'/>");  // Catches enter in a text field without saving
-	
+
 	if(!(fields contains "tab")) {
 		if(fields contains "last_tab")
 			fields["tab"] = fields["last_tab"];
@@ -1013,9 +1013,9 @@ void main() {
 			fields["editTab"] = fields["last_editTab"];
 		else fields["editTab"] = "Search";
 	}
-	if(fields contains "searchbox") 
+	if(fields contains "searchbox")
 		search = search_items(fields["searchbox"]);
-	
+
 	# foreach x,y in fields print(x + " - "+ y); print("==============================");
 	boolean noSave = fields["tab"] == "Information" || (fields["tab"] == "Edit Database" && fields["editTab"] == "Search" && (count(search) == 0));
 
@@ -1031,7 +1031,7 @@ void main() {
 		} else if(!noSave) page.append("Save all changes above");
 		page.append("</td></tr></table>");
 	}
-	
+
 	page.append("<ul class='tabbernav'>");
 	write_tab("tab", "Information");
 	write_tab("tab", "Add Items");
@@ -1072,7 +1072,7 @@ void main() {
 			break;
 		}
 	}
-	
+
 	if(noSave)
 		page.append("&nbsp;");
 	else {
@@ -1106,13 +1106,13 @@ void main() {
 	} else if(!noSave) page.append("Save all changes above");
 	if(!noSave)
 		page.append("</td></tr></table>");
-	
+
 	// Ensure nothing is forgotten when tabs are switched
 	if(success)
 		foreach key, value in fields
 			 if(!(page.contains_text(key) || key.contains_text("tab")))
 				write_hidden(value, key);
-	
+
 	page.append("</form></body></html>"); 	// finish_page()
 	writeln(page);
 }

--- a/release/scripts/OCD Inventory Control.ash
+++ b/release/scripts/OCD Inventory Control.ash
@@ -72,7 +72,7 @@ boolean is_wadable(item it) {
 	switch(it) {
 	case $item[sewer nuggets]:
 	case $item[floaty sand]:
-	case $item[floaty pebbles]: 
+	case $item[floaty pebbles]:
 	case $item[floaty gravel]:
 		return true;
 	}
@@ -157,12 +157,12 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 	command ["CLAN"]  = "stash put ";
 	command ["GIFT"] = "send gift to ";
 	command ["KBAY"] = "kBay ";
-	
+
 	// Save these so they can be screwed with safely
 	boolean autoSatisfyWithCloset = get_property("autoSatisfyWithCloset").to_boolean();
 	boolean autoSatisfyWithStorage = get_property("autoSatisfyWithStorage").to_boolean();
 	boolean autoSatisfyWithStash = get_property("autoSatisfyWithStash").to_boolean();
-	
+
 	boolean use_multi = getvar("BaleOCD_MallMulti") != "" && to_boolean(getvar("BaleOCD_UseMallMulti"));
 	if(use_multi)
 		command ["MALL"] = "send to mallmulti "+ getvar("BaleOCD_MallMulti") + ": ";
@@ -212,13 +212,13 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 		if(full > OCD[it].q && available_amount(it) > item_amount(it))
 			retrieve_item(min(full - OCD[it].q, available_amount(it)), it);
 		// Don't OCD items that are part of stock. Stock can always be satisfied by closet.
-		int keep = getvar("BaleOCD_Stock") == "0" ? ocd[it].q: 
+		int keep = getvar("BaleOCD_Stock") == "0" ? ocd[it].q:
 			max(ocd[it].q, stock[it].q - (get_property("autoSatisfyWithCloset") == "false"? 0: closet_amount(it)));
 		// OCD is limited by item_amount(it) since we don't want to purchase anything and closeted items
 		// may be off-limit, but if there's something in the closet, it counts against the amount you own.
 		return min(full - keep, item_amount(it));
 	}
-	
+
 	boolean AskUser = true;  // Once this has been set false, it will be false for all successive calls to the function
 	boolean check_inventory(boolean StopForMissingItems) {
 		AskUser = AskUser && StopForMissingItems;
@@ -305,7 +305,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			} else {
 				if(stop_for_relay(doodad))
 					return false;
-				// Potentially disasterous, but this will cause the script to sell off unlisted items, just like it used to. 
+				// Potentially disasterous, but this will cause the script to sell off unlisted items, just like it used to.
 				if(getvar("BaleOCD_MallDangerously").to_boolean())
 					mall[doodad] = excess;   // Backwards compatibility FTW!
 			}
@@ -323,15 +323,15 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			return max(to_int(ocd[it].info), price);
 		return price;
 	}
-	
+
 	void print_cat(int [item] cat, string act, string to) {
 		if(count(cat) < 1) return;
-	
+
 		item [int] catOrder;
 		foreach it in cat
 			catOrder[ count(catOrder) ] = it;
 		sort catOrder by to_lower_case(to_string(value));
-		
+
 		int len, total, linevalue;
 		buffer queue;
 		int [item] kBayCount, kBayClear;
@@ -422,18 +422,18 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 		#	vprint("Minimum biding for all auctions = "+rnum(total), "blue", 3);
 		FinalSale += total;
 	}
-	
+
 	item other_clover(item it) {
 		if(it == $item[ten-leaf clover]) return $item[disassembled clover];
 		return $item[ten-leaf clover];
 	}
-	
+
 	// This is only called if the player has both kinds of clovers, so no need to check if stock contains both
 	int clovers_needed() {
 		return stock[$item[ten-leaf clover]].q + stock[$item[disassembled clover]].q
 		  - full_amount($item[ten-leaf clover]) - full_amount($item[disassembled clover]);
 	}
-	
+
 	boolean stock() {
 		boolean success = true;
 		boolean first = true;
@@ -443,7 +443,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			if(first) first = !vprint("Stocking up on required items!", "blue", 3);
 			return retrieve_item(q, it);
 		}
-		
+
 		load_OCD();
 		batch_open();
 		foreach it in stock {
@@ -458,7 +458,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			}
 			// Closet everything (except for gear) that is stocked so it won't get accidentally used.
 			if(it.to_slot() == $slot[none] && stock[it].q - ocd[it].q > closet_amount(it) && item_amount(it) > ocd[it].q)
-				put_closet(min(item_amount(it) - ocd[it].q, stock[it].q - ocd[it].q - closet_amount(it)), it); 
+				put_closet(min(item_amount(it) - ocd[it].q, stock[it].q - ocd[it].q - closet_amount(it)), it);
 			// If you got clovers, closet them before they get protected into disassembled clovers.
 			//if(it == $item[ten-leaf clover] && to_boolean(get_property("cloverProtectActive")))
 			//	put_closet(item_amount(it), it);
@@ -473,7 +473,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			for x from 1438 to 1443 if(OCD[to_item(x)].action == "PULV") return "nuggets";
 			return "";
 		}
-		
+
 		boolean malusOnly = true;
 		foreach thing, quant in pulverize
 			if(thing.is_wadable()) {
@@ -662,12 +662,12 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 	}
 
 	boolean act_cat(int [item] cat, string act, string to) {
-	
+
 		item [int] catOrder;
 		foreach it in cat
 			catOrder[ count(catOrder) ] = it;
 		sort catOrder by to_lower_case(to_string(value));
-		
+
 		if(count(cat) == 0) return false;
 		int i = 0;
 		if(act == "TODO" && count(todo) > 0)
@@ -769,7 +769,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			print("You are missing item stocking information.", "red");
 			return false;
 		}
-		
+
 		if(!check_inventory(StopForMissingItems)) return false;
 		if(act_cat(brak, "BREAK", "") && !check_inventory(StopForMissingItems))
 			return false;
@@ -783,7 +783,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			return false;
 		if(act_cat(pulv, "PULV", "") && !check_inventory(StopForMissingItems))
 			return false;
-		
+
 		act_cat(mall, "MALL", "");
 		act_cat(auto, "AUTO", "");
 		act_cat(disc, "DISC", "");
@@ -802,7 +802,7 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 				vprint("Minimum biding for all auctions = "+rnum(kBidTot), "blue", 3);
 			FinalSale += kBidTot; */
 		}
-		
+
 		if(getvar("BaleOCD_Stock") == "1" && !getvar("BaleOCD_Sim").to_boolean())
 			stock();
 
@@ -815,18 +815,18 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 
 // *******  Finally, here is the main for ocd_control()
 // int ocd_control(boolean StopForMissingItems) {
-	
+
 	cli_execute("inventory refresh");
-	
+
 	// Empty closet before emptying out Hangks, otherwise it may interfere with which Hangk's items go to closet
-	if(to_int(getvar("BaleOCD_EmptyCloset")) >= 0 && get_property("lastEmptiedStorage").to_int() != my_ascensions() 
+	if(to_int(getvar("BaleOCD_EmptyCloset")) >= 0 && get_property("lastEmptiedStorage").to_int() != my_ascensions()
 	  && getvar("BaleOCD_Sim") == "false")
 		empty_closet();
-	
+
 	// Empty out Hangks, so it can be accounted for by what follows.
 	if(autoSatisfyWithStorage && get_property("lastEmptiedStorage").to_int() != my_ascensions())
 		 visit_url("storage.php?action=pullall&pwd");
-	
+
 	boolean success;
 	try {
 		if(autoSatisfyWithCloset)


### PR DESCRIPTION
**Note: This depends on (and should be merged after) #3.**

This PR does two things:

- Extract CSS and JavaScript code (that were previously inlined with `<script>` and `<style>` tags) into separate files. This makes maintenance easier, because we can now use syntax highlighting, linting, and formatting tools provided by code editors.
- Clean up trailing whitespace in ASH files. This doesn't affect functionality, but plays nice with code editors that automatically remove trailing whitespace anyway.

@Rinn I'm requesting a review, since you're the only person I know who has shown interest in maintaining this repo. If anyone else would like to review this, please feel free.