### PR TITLE
Fix self-upgrading code, add upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ OCD Inventory Control provides a relay script for configuration.
 1. Open the relay browser. In the top menu, click the "-run script-" dropdown, then "OCD dB Manager".
 2. If this is your first time, OCD will display "**All item information is corrupted or missing.**"
    Don't worry! Click on the "Add Items" tab to proceed.
-4. You will be presented with a gigantic table of `(uncategorized)` items.
-3. For each item, choose what you want to do with the item.
-   - *You don't need to categorize everything now*. You can always come back and finish the list later.
-4. When you're done, click the "Save All" button at the top (or bottom) of the table.
+3. You will be presented with a gigantic table of `(uncategorized)` items.
+4. For each item, choose what you want to do with the item.
+   - _You don't need to categorize everything now_. You can always come back and finish the list later.
+5. When you're done, click the "Save All" button at the top (or bottom) of the table.
    - Your changes are not saved until you hit "Save All". To discard your changes, click any other link (e.g. Main Map) to exit the script.
    - You can also click the "Edit Database" tab to modify your choices.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ This is a fork of [OCD Inventory Control](https://kolmafia.us/threads/ocd-invent
 
 ## Installing
 
+### Migrating from Bale's OCD Inventory Control
+
+If you are upgrading from Bale's original script, run the following commands in KoLmafia to delete old versions of OCD:
+
+```
+svn delete bale-ocd
+svn delete Loathing-Associates-Scripting-Society-OCD-Inventory-Control-trunk
+```
+
+Then proceed below.
+
+### New Users
+
 To install this script, type the following into KoLmafia's gCLI:
 
 ```

--- a/release/scripts/OCD Inventory Control.ash
+++ b/release/scripts/OCD Inventory Control.ash
@@ -21,10 +21,11 @@ setvar("BaleOCD_MallDangerously", FALSE);  // If this set to TRUE, any uncategor
 
 // Check version! This will check both scripts and data files.
 // This code is at base level so that the relay script's importation will automatically cause it to be run.
-if(svn_exists("bale-ocd") && get_property("_svnUpdated") == "false" && get_property("_ocdUpdated") != "true") {
-	if(!svn_at_head("bale-ocd")) {
+string __OCD_PROJECT_NAME__ = "Loathing-Associates-Scripting-Society-OCD-Inventory-Control-trunk-release";
+if(svn_exists(__OCD_PROJECT_NAME__) && get_property("_svnUpdated") == "false" && get_property("_ocdUpdated") != "true") {
+	if(!svn_at_head(__OCD_PROJECT_NAME__)) {
 		print("OCD Inventory Control has become outdated. Automatically updating from SVN...", "red");
-		cli_execute("svn update bale-ocd");
+		cli_execute("svn update " + __OCD_PROJECT_NAME__);
 		print("On the script's next invocation it will be up to date.", "green");
 	}
 	set_property("_ocdUpdated", "true");


### PR DESCRIPTION
Fix the self-upgrading code to use the new project name. This is possibly what caused #7; even if it was not, it would certainly prevent weird SVN shenanigans down the road.

Also add instructions for people migrating from Bale's original OCD script.